### PR TITLE
Check context on instance of Throwable

### DIFF
--- a/SentryTarget.php
+++ b/SentryTarget.php
@@ -67,7 +67,7 @@ class SentryTarget extends Target
             list($context, $level, $category, $timestamp, $traces) = $message;
             $extra = [];
 
-            if ($context instanceof \Exception) {
+            if ($context instanceof \Throwable || $context instanceof \Exception) {
                 $this->client->captureException($context);
                 $description = $context->getMessage();
             } elseif (isset($context['msg'])) {


### PR DESCRIPTION
Added compatibility with `Error` added to the **php 7**

Made by analogy with [`yii\log\Target`](https://github.com/yiisoft/yii2/blob/master/framework/log/Target.php#L257)
