### PR TITLE
Update SentryTarget.php

### DIFF
--- a/src/SentryTarget.php
+++ b/src/SentryTarget.php
@@ -91,6 +91,15 @@ class SentryTarget extends Target
                 }
 
                 $data['extra'] = $text;
+                
+                if (!empty($data['extra'])) {
+                    \Sentry\configureScope(function (\Sentry\State\Scope $scope) use ($data): void {
+                        foreach ($data['extra'] as $key => $value) {
+                            $scope->setExtra((string)$key, $value);
+                        }
+                    });
+                }
+                
             } else {
                 $data['message'] = $text;
             }


### PR DESCRIPTION
Доп переменные не пробрасываются

        \Yii::error([
            'msg' => 'message_1',
            'key1' => '1111',
            'key2' => '2222',
            'key3' => ['key4' => '4444', 'key5' => '5555'],
        ], 'category_1');