### PR TITLE
Array export fix if text not contains 'message' key

### DIFF
--- a/src/SentryTarget.php
+++ b/src/SentryTarget.php
@@ -108,7 +108,7 @@ class SentryTarget extends Target
             if ($this->context) {
                 $data['extra']['context'] = parent::getContextMessage();
             }
-            if(!isset($data['message'])) {
+            if (!isset($data['message'])) {
                 $data['message'] = VarDumper::dumpAsString($text);
             }
 

--- a/src/SentryTarget.php
+++ b/src/SentryTarget.php
@@ -7,6 +7,7 @@
 namespace notamedia\sentry;
 
 use yii\helpers\ArrayHelper;
+use yii\helpers\VarDumper;
 use yii\log\Logger;
 use yii\log\Target;
 
@@ -107,9 +108,12 @@ class SentryTarget extends Target
             if ($this->context) {
                 $data['extra']['context'] = parent::getContextMessage();
             }
+            if(!isset($data['message'])) {
+                $data['message'] = VarDumper::dumpAsString($text);
+            }
 
             $data = $this->runExtraCallback($text, $data);
-            \Sentry\captureMessage($data['message']);
+            \Sentry\captureMessage($data['message'] ?? '');
         }
     }
 


### PR DESCRIPTION
use case:

```php
Yii::error($model->errors);
Yii::error($array);
```