### PR TITLE
Respect Exception information from the log entry data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
+  - 8.0
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "type": "yii2-extension",
   "license": "MIT",
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "yiisoft/yii2": "^2.0",
     "sentry/sdk": "^3.0"
   },

--- a/src/SentryTarget.php
+++ b/src/SentryTarget.php
@@ -131,7 +131,7 @@ class SentryTarget extends Target
                         unset($text['tags']);
                     }
 
-                    if (isset($text['exception'])) {
+                    if (isset($text['exception']) && $text['exception'] instanceof Throwable) {
                         $data['exception'] = $text['exception'];
                         unset($text['exception']);
                     }

--- a/src/SentryTarget.php
+++ b/src/SentryTarget.php
@@ -118,11 +118,11 @@ class SentryTarget extends Target
             \Sentry\withScope(function (Scope $scope) use ($text, $level, $data) {
                 if (is_array($text)) {
                     if (isset($text['msg'])) {
-                        $data['message'] = $text['msg'];
+                        $data['message'] = (string)$text['msg'];
                         unset($text['msg']);
                     }
                     if (isset($text['message'])) {
-                        $data['message'] = $text['message'];
+                        $data['message'] = (string)$text['message'];
                         unset($text['message']);
                     }
 


### PR DESCRIPTION
According to PSR3,

> If an Exception object is passed in the context data, it MUST be in
the 'exception' key. Logging exceptions is a common pattern and this
allows implementors to extract a stack trace from the exception when the
log backend supports it. Implementors MUST still verify that the
'exception' key is actually an Exception before using it as such, as it
MAY contain anything.

This Pull Requests implements `exception` context property handling and adds support for both `msg` and `message` for the compatibility reasons.

It also allows PHP8 support