### PR TITLE
Collecting breadcrumbs and stacktraces

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ Example:
 
 More about tags see https://docs.sentry.io/learn/context/#tagging-events
 
+
+### Breadcrumbs
+
+All messages will be added to Breadcrumbs display.
+
+You can mark breadcrumbs with type:
+
+```php
+\Yii::warning([
+    'msg' => 'message',
+    'type' => \Sentry\Breadcrumb::TYPE_HTTP,
+], 'category');
+```
+
+More about breadcrumbs see https://docs.sentry.io/product/error-monitoring/breadcrumbs/
+
 ### Additional context
 
 You can add additional context (such as user information, fingerprint, etc) by calling `\Sentry\configureScope()` before logging.

--- a/src/SentryTarget.php
+++ b/src/SentryTarget.php
@@ -6,15 +6,19 @@
 
 namespace notamedia\sentry;
 
+use Sentry\Breadcrumb;
 use Sentry\ClientBuilder;
 use Sentry\Event;
 use Sentry\EventHint;
+use Sentry\Frame;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\ExceptionListenerIntegration;
 use Sentry\Integration\FatalErrorListenerIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\SentrySdk;
+use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Severity;
+use Sentry\StacktraceBuilder;
 use Sentry\State\Scope;
 use Throwable;
 use Yii;
@@ -49,6 +53,13 @@ class SentryTarget extends Target
     public $extraCallback;
 
     /**
+     * @var StacktraceBuilder Builder fo creation stack trace frames
+     *
+     * It available in \Sentry\Client, but it`s private.
+     */
+    protected $stacktraceBuilder;
+
+    /**
      * @inheritDoc
      */
     public function __construct($config = [])
@@ -77,6 +88,8 @@ class SentryTarget extends Target
         });
 
         SentrySdk::init()->bindClient($builder->getClient());
+
+        $this->stacktraceBuilder = new StacktraceBuilder($options, new RepresentationSerializer($options));
     }
 
     /**
@@ -90,10 +103,38 @@ class SentryTarget extends Target
     /**
      * @inheritdoc
      */
+    public function collect($messages, $final)
+    {
+        foreach ($messages as $message) {
+            list($text, $level, $category, $timestamp, $traces) = $message;
+
+            [$message, $tags, $exception, $type, $extra] = $this->parseText($text);
+
+            $metadata = [];
+            if(!empty($tags))
+                $metadata['tags'] = $tags;
+
+            if(!empty($exception))
+                $metadata['exception'] = $exception;
+
+            if(!empty($extra))
+                $metadata['extra'] = $extra;
+
+            // $timestamp parameter will be added soon
+            // @see https://github.com/getsentry/sentry-php/pull/1193
+            $bc = new Breadcrumb($this->getLogLevel($level), $type, $category, $message, $metadata, $timestamp);
+            \Sentry\addBreadcrumb($bc);
+        }
+        parent::collect($messages, $final);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function export()
     {
         foreach ($this->messages as $message) {
-            [$text, $level, $category] = $message;
+            [$text, $level, $category, $timestamp, $traces] = $message;
 
             $data = [
                 'message' => '',
@@ -115,31 +156,10 @@ class SentryTarget extends Target
                 }
             } catch (Throwable $e) {}
 
-            \Sentry\withScope(function (Scope $scope) use ($text, $level, $data) {
-                if (is_array($text)) {
-                    if (isset($text['msg'])) {
-                        $data['message'] = (string)$text['msg'];
-                        unset($text['msg']);
-                    }
-                    if (isset($text['message'])) {
-                        $data['message'] = (string)$text['message'];
-                        unset($text['message']);
-                    }
+            \Sentry\withScope(function (Scope $scope) use ($text, $level, $timestamp, $traces, $data) {
+                [$data['message'], $tags, $data['exception'], $breadcrumbType, $data['extra']] = $this->parseText($text);
 
-                    if (isset($text['tags'])) {
-                        $data['tags'] = ArrayHelper::merge($data['tags'], $text['tags']);
-                        unset($text['tags']);
-                    }
-
-                    if (isset($text['exception']) && $text['exception'] instanceof Throwable) {
-                        $data['exception'] = $text['exception'];
-                        unset($text['exception']);
-                    }
-
-                    $data['extra'] = $text;
-                } else {
-                    $data['message'] = (string) $text;
-                }
+                $data['tags'] = ArrayHelper::merge($data['tags'], $tags);
 
                 if ($this->context) {
                     $data['extra']['context'] = parent::getContextMessage();
@@ -148,9 +168,7 @@ class SentryTarget extends Target
                 $data = $this->runExtraCallback($text, $data);
 
                 $scope->setUser($data['userData']);
-                foreach ($data['extra'] as $key => $value) {
-                    $scope->setExtra((string) $key, $value);
-                }
+
                 foreach ($data['tags'] as $key => $value) {
                     if ($value) {
                         $scope->setTag($key, $value);
@@ -163,13 +181,73 @@ class SentryTarget extends Target
                     $event = Event::createEvent();
                     $event->setMessage($data['message']);
                     $event->setLevel($this->getLogLevel($level));
+                    $event->setTimestamp($timestamp);
 
                     \Sentry\captureEvent($event, EventHint::fromArray(array_filter([
                         'exception' => $data['exception'] ?? null,
+                        'extra' => $data['extra'] ?? [],
+                        'stacktrace' => $this->buildStacktrace($traces),
                     ])));
                 }
             });
         }
+    }
+
+    /**
+     * Parse the text variable
+     * @param $text
+     * @return array
+     */
+    protected function parseText($text)
+    {
+        $message = '';
+        $tags = [];
+        $exception = null;
+        $extra = [];
+        $type = Breadcrumb::TYPE_DEFAULT;
+        if (is_array($text)) {
+            if (isset($text['msg'])) {
+                $message = (string)$text['msg'];
+                unset($text['msg']);
+            }
+
+            if (isset($text['message'])) {
+                $message = (string)$text['message'];
+                unset($text['message']);
+            }
+
+            if (isset($text['tags'])) {
+                $tags = (array)$text['tags'];
+                unset($text['tags']);
+            }
+
+            if (isset($text['type'])) {
+                $type = $text['type'];
+                unset($text['type']);
+            }
+
+            if (isset($text['exception']) && $text['exception'] instanceof Throwable) {
+                $exception = $text['exception'];
+                unset($text['exception']);
+            }
+            $extra = $text;
+        } else {
+            $message = (string) $text;
+        }
+        return [$message, $tags, $exception, $type, $extra];
+    }
+
+    /**
+     * Builds \Sentry\Stacktrace from traces array
+     * @param $traces Yii message traces
+     * @return null|\Sentry\Stacktrace
+     */
+    protected function buildStacktrace($traces)
+    {
+        if(is_array($traces) && ! empty($traces)) {
+            return $this->stacktraceBuilder->buildFromBacktrace($traces, Frame::INTERNAL_FRAME_FILENAME , 0);
+        }
+        return null;
     }
 
     /**

--- a/src/SentryTarget.php
+++ b/src/SentryTarget.php
@@ -111,13 +111,13 @@ class SentryTarget extends Target
             [$message, $tags, $exception, $type, $extra] = $this->parseText($text);
 
             $metadata = [];
-            if(!empty($tags))
+            if (!empty($tags))
                 $metadata['tags'] = $tags;
 
-            if(!empty($exception))
+            if (!empty($exception))
                 $metadata['exception'] = $exception;
 
-            if(!empty($extra))
+            if (!empty($extra))
                 $metadata['extra'] = $extra;
 
             // $timestamp parameter will be added soon
@@ -154,7 +154,8 @@ class SentryTarget extends Target
                 if ($user && ($identity = $user->getIdentity(false))) {
                     $data['userData']['id'] = $identity->getId();
                 }
-            } catch (Throwable $e) {}
+            } catch (Throwable $e) {
+            }
 
             \Sentry\withScope(function (Scope $scope) use ($text, $level, $timestamp, $traces, $data) {
                 [$data['message'], $tags, $data['exception'], $breadcrumbType, $data['extra']] = $this->parseText($text);
@@ -232,7 +233,7 @@ class SentryTarget extends Target
             }
             $extra = $text;
         } else {
-            $message = (string) $text;
+            $message = (string)$text;
         }
         return [$message, $tags, $exception, $type, $extra];
     }
@@ -244,8 +245,8 @@ class SentryTarget extends Target
      */
     protected function buildStacktrace($traces)
     {
-        if(is_array($traces) && ! empty($traces)) {
-            return $this->stacktraceBuilder->buildFromBacktrace($traces, Frame::INTERNAL_FRAME_FILENAME , 0);
+        if (is_array($traces) && !empty($traces)) {
+            return $this->stacktraceBuilder->buildFromBacktrace($traces, Frame::INTERNAL_FRAME_FILENAME, 0);
         }
         return null;
     }


### PR DESCRIPTION
This Pull Requests implements tracking all events with `\Sentry\Breadcrumb` to display in Breadcrumbs display.
Also implemented collecting `$traces` into `\Sentry\Stacktrace`