### PR TITLE
Add TagsCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Writing messages with extra data:
 ], 'category');
 ```
 
-### Extra callback
+### Extra/Tags callback
 
 `extraCallback` property can modify extra's data as callable function:
  
@@ -66,10 +66,17 @@ Writing messages with extra data:
                 // some manipulation with data
                 $extra['some_data'] = \Yii::$app->someComponent->someMethod();
                 return $extra;
-            }
+            },
+            'tagsCallback' => function ($message, $tags) {
+                // some manipulation with tags
+                $tags['custom_tag'] = \Yii::$app->someComponent->getTag();
+                return $tags;
+            }		
         ],
     ],
 ```
+
+
 
 ### Tags
 

--- a/src/SentryTarget.php
+++ b/src/SentryTarget.php
@@ -48,7 +48,7 @@ class SentryTarget extends Target
      */
     public $extraCallback;
     /**
-     * @var callable Callback function that can modify extra's array
+     * @var callable Callback function that can modify tags array
      */
     public $tagsCallback;
 

--- a/src/SentryTarget.php
+++ b/src/SentryTarget.php
@@ -47,6 +47,10 @@ class SentryTarget extends Target
      * @var callable Callback function that can modify extra's array
      */
     public $extraCallback;
+    /**
+     * @var callable Callback function that can modify extra's array
+     */
+    public $tagsCallback;
 
     /**
      * @inheritDoc
@@ -145,12 +149,14 @@ class SentryTarget extends Target
                     $data['extra']['context'] = parent::getContextMessage();
                 }
 
-                $data = $this->runExtraCallback($text, $data);
-
                 $scope->setUser($data['userData']);
+                
+                $data = $this->runExtraCallback($text, $data);
                 foreach ($data['extra'] as $key => $value) {
                     $scope->setExtra((string) $key, $value);
                 }
+                
+                $data = $this->runTagsCallback($text, $data);
                 foreach ($data['tags'] as $key => $value) {
                     if ($value) {
                         $scope->setTag($key, $value);
@@ -189,6 +195,23 @@ class SentryTarget extends Target
         return $data;
     }
 
+    /**
+     * Calls the tags callback if it exists
+     *
+     * @param mixed $text
+     * @param array $data
+     *
+     * @return array
+     */
+    public function runTagsCallback($text, $data)
+    {
+        if (is_callable($this->tagsCallback)) {
+            $data['tags'] = call_user_func($this->tagsCallback, $text, $data['tags'] ?? []);
+        }
+
+        return $data;
+    }    
+    
     /**
      * Returns the text display of the specified level for the Sentry.
      *


### PR DESCRIPTION
The reason why we need `tagsCallback`, because some notification providers (eg Telegram) can access only tags, not extra data.